### PR TITLE
restore mqtt function in oisp-admin, config and cloud proxy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,14 +136,14 @@ jobs:
     executor: vm-executor
     steps:
       - checkout-e2e:
-          oisp-git-hash: "5e0076bced308973a36936950dd9acdf0ee8a1bc"
+          oisp-git-hash: "v1.1.1-beta.1"
       - checkout-testbranch:
           repo: "oisp-iot-agent"
       - setup-build-environment
       - pull-images:
-          oisp-tag: "nightly-2019-07-17"
+          oisp-tag: "v1.1.1-beta.1"
       - e2e-test:
-          oisp-docker-tag: "nightly-2019-07-17"
+          oisp-docker-tag: "v1.1.1-beta.1"
       - test-admin
       - test-agent
   build-check:

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ or when the oisp-agent is launched, by sending
 ```
 to a UDP socket on port 41234.
 
+Dependent of the configuration, the agent sends data with REST or MQTT. If MQTT is configured, agent and admin always try to use MQTT for data submission. All other calls, like activation of devices or registration of components is always done with REST. Therefore, until further notice the default protocol should always be "rest+ws". The control channel which can receive commands from OISP will always be WS. MQTT control messages are Work in Progress and available soon.
+
 #### Starting the Agent
 
 To start the oisp-agent service simply execute the start script:

--- a/admin/configurator.js
+++ b/admin/configurator.js
@@ -82,7 +82,7 @@ module.exports = {
             .command('protocol <protocol>')
             .description('Set the protocol to \'rest\' or \'rest+ws\'')
             .action(function(protocol) {
-                if (protocol === 'rest' || protocol === 'rest+ws') {
+                if (protocol === 'mqtt' || protocol === 'rest' || protocol === 'rest+ws') {
                     common.saveToConfig(configFileKey.defaultConnector, protocol);
                     logger.info("protocol set to: " + protocol);
                 } else {

--- a/admin/operational.js
+++ b/admin/operational.js
@@ -70,6 +70,11 @@ function testConnection () {
                 logger.info("Environment: %s", res.currentSetting);
                 logger.info("Build: %s", res.build);
                 logger.debug("Full response %j", res );
+                if (res.mqtt === 1) {
+                    logger.info("MQTT ok")
+                } else {
+                    logger.warn("MQTT failed or not configured");
+                }
             } else {
                 logger.error("Connection failed to %s", host);
                 exitCode = exitMessageCode.ERROR;

--- a/config/config.json.template
+++ b/config/config.json.template
@@ -40,6 +40,23 @@
 				"host": false,
 				"port": false
 			}
+		},
+		"mqtt": {
+			"host": "localhost",
+			"port": 8883,
+			"qos": 1,
+			"retain": false,
+			"secure": true,
+			"strictSSL": true,
+			"retries": 5,
+			"topic": {
+				"metric_topic": "server/metric/{accountid}/{deviceid}",
+				"health": "server/devices/{deviceid}/health",
+				"health_status": "device/{deviceid}/health",
+				"control_command": "device/{gwid}/control",
+				"ingestion_response": "device/{deviceid}/metric/response",
+				"actuation": "device/metric/{deviceid}/actuation"
+			}
 		}
 	}
 }

--- a/lib/cloud.proxy.js
+++ b/lib/cloud.proxy.js
@@ -46,7 +46,15 @@ function IoTKitCloud(logger, deviceId, customProxy) {
     me.gatewayId = deviceConf.gateway_id || deviceId;
     me.store = Sensor.init("device.json", me.logger);
     me.activationCode = deviceConf.activation_code;
-    me.logger.debug('Cloud Proxy Created with Cloud Handler ', me.proxy.type);
+    me.logger.info('Cloud Proxy Created with Cloud Handler', me.proxy.type);
+    //set mqtt proxy if PROVIDED
+    if (conf.connector.mqtt != undefined) {
+        var mqttConf = Object.assign({}, conf);
+        mqttConf.default_connector = "mqtt";
+        me.mqttProxy = require('@open-iot-service-platform/oisp-sdk-js')(mqttConf).lib.proxies.getProxyConnector();
+        me.logger.info("Mqtt proxy found! Configuring MQTT for data sending.");
+        me.mqttProxy.setCredential(me.deviceId, deviceConf.device_token);
+    }
 }
 IoTKitCloud.prototype.isActivated = function () {
     var me = this;
@@ -208,14 +216,49 @@ IoTKitCloud.prototype.dataSubmit = function (metric, callback) {
     metric.did = me.deviceId;
     metric.gatewayId = me.gatewayId;
     metric.deviceToken = me.secret.deviceToken;
-    me.logger.debug("Metric doc: %j", metric, {});
-    me.proxy.data(metric, function (dato) {
-        if (callback) {
-            return callback(dato);
-        }
-        return true;
-    });
 
+    if (me.mqttProxy != undefined) {
+        //the next few lines are needed as workaround to work with current sdk
+        //once SDK has been updated this can be removed ...
+        metric.data.forEach(function(element) {
+            element.componentId = element.cid
+            delete element.cid
+        });
+        var data = {
+            deviceId: me.deviceId,
+            deviceToken: metric.deviceToken,
+            body: {
+                accountId: metric.accountId,
+                on: new Date().getTime(),
+                data: metric.data
+            }
+        }
+        data.convertToMQTTPayload = function() {
+            delete this.convertToMQTTPayload;
+            return this;
+        }
+        data.did = metric.did;
+        data.accountId = metric.accountId;
+        me.logger.debug("MQTT Metric: %j", data, {});
+        me.mqttProxy.data(data, function(err, response) {
+            if (err) {
+                callback(err)
+            } else {
+                if (response) {
+                    callback(null, response)
+                }
+            }
+        });
+        // ...until here
+    } else {
+        me.logger.debug("Rest Metric: %j", metric, {});
+        me.proxy.data(metric, function (dato) {
+            if (callback) {
+                return callback(dato);
+            }
+            return true;
+        })
+    }
 };
 IoTKitCloud.prototype.regComponent = function(comp, callback) {
     var me = this;
@@ -238,10 +281,24 @@ IoTKitCloud.prototype.desRegComponent = function() {
 
 IoTKitCloud.prototype.test = function(callback) {
     var me = this;
-    me.logger.info("Trying to connect to host ...");
+    me.logger.info("Trying to connect to host with REST...");
     me.proxy.health(me.deviceId, function (result) {
-        me.logger.debug("Response ", result);
-        callback(result);
+        me.logger.info("Response ", result);
+        if (me.mqttProxy != undefined) {
+            me.logger.info("Testing MQTT ...");
+            var done = 0;
+            var resultFunc = function(resultMQTT) {
+                if (done) {
+                    return;
+                }
+                me.logger.debug("MQTT Response ", resultMQTT);
+                result.mqtt = resultMQTT;
+                done = 1;
+                callback(result);
+            }
+            setTimeout(resultFunc, 5000, 0);
+            me.mqttProxy.health(me.deviceId, resultFunc);
+        }
     });
 };
 

--- a/lib/cloud.proxy.js
+++ b/lib/cloud.proxy.js
@@ -53,7 +53,17 @@ function IoTKitCloud(logger, deviceId, customProxy) {
         mqttConf.default_connector = "mqtt";
         me.mqttProxy = require('@open-iot-service-platform/oisp-sdk-js')(mqttConf).lib.proxies.getProxyConnector();
         me.logger.info("Mqtt proxy found! Configuring MQTT for data sending.");
-        me.mqttProxy.setCredential(me.deviceId, deviceConf.device_token);
+        // if no deviceToken is defined, health check will not work
+        // Reason: the /health path in mqtt needs auth as well
+        // this has to change, but until then, health check will be disabled
+        // when no device token is available
+        if (deviceConf.device_token) {
+            me.logger.info("Set Username and Password for MQTT channel.");
+            me.mqttProxy.setCredential(me.deviceId, deviceConf.device_token);
+        } else {
+            me.logger.info("No credentials found for MQTT. Disable MQTT test");
+            me.mqttProxy = undefined;
+        }
     }
 }
 IoTKitCloud.prototype.isActivated = function () {
@@ -298,6 +308,8 @@ IoTKitCloud.prototype.test = function(callback) {
             }
             setTimeout(resultFunc, 5000, 0);
             me.mqttProxy.health(me.deviceId, resultFunc);
+        } else {
+            callback(result);
         }
     });
 };

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "es6-shim": "0.35.5",
     "express": "^4.17.1",
     "getmac": "^1.4.6",
-    "json-schema": "^0.2.3",
+    "json-schema": "^0.2.5",
     "json-socket": "^0.3.0",
     "mqtt": "^3.0.0",
     "uuid": "^3.3.2",

--- a/test/lib_agentTests.js
+++ b/test/lib_agentTests.js
@@ -202,8 +202,8 @@ describe('oisp-agent/lib/schemaValidation', function() {
         };
         var wrongmessage = [{
             property: '',
-            message: 'string value found, but a boolean is required',
-            customMessage: ' string value found, but a boolean is required'
+            message: 'bbb - string value found, but a boolean is required',
+            customMessage: ' bbb - string value found, but a boolean is required'
         }];
         //console.log(schemaValidation.validate(obj, schema));
         assert.deepEqual(schemaValidation.validate(obj, schema), wrongmessage, 'not get expected messege');


### PR DESCRIPTION
* Reintegrated MQTT in Cloud Proxy. REST+WS are always default protocol. Only when MQTT is defined, the agent will use MQTT for data sending
* updated config template and removed unneeded debug output
* Added MQTT admin Test for MQTT connection

Signed-off-by: Marcel Wagner <wagmarcel@web.de>