### PR TITLE
Updates to work with changes in OISP MQTT service:

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.16.0-alpine
+FROM node:10.19.0-alpine
 
 ADD . /app
 

--- a/container/Dockerfile.testsensor
+++ b/container/Dockerfile.testsensor
@@ -1,4 +1,4 @@
-FROM node:8.16.0-alpine
+FROM node:10.19.0-alpine
 
 ADD ./scripts/testsensor /app
 

--- a/container/scripts/testsensor/testsensor.js
+++ b/container/scripts/testsensor/testsensor.js
@@ -37,6 +37,7 @@ var default_sensorSpecs = [
 	componentName: "temp",
 	componentType: "temperature.v1.0",
 	type: "number",
+  sleep: 5000,
 	sigma: 0.3,
 	startValue: 20
     }
@@ -63,6 +64,10 @@ if (process.env.TEST_SAMPLES) {
 }
 
 var registerComponent = function(spec) {
+    spec.compRegistering++;
+    if (spec.compRegistering > 5) {
+      return;
+    }
     var component = { "t": spec.componentType, "n": spec.componentName }
     var comp_message = new Buffer(JSON.stringify(component));
     spec.agents.forEach(function(agent){
@@ -93,6 +98,7 @@ var getRandomInteger = function(min, max) {
 //initialize all values
 sensorSpecs.forEach(function(spec) {
     values[spec.name] = spec.startValue;
+    spec.compRegistering = 0;
 });
 
 //first register the temp component
@@ -102,6 +108,10 @@ sensorSpecs.forEach(function(spec) {
 });
 
 sensorSpecs.forEach(function(spec){
+    var sleeptime = 5000;
+    if (spec.sleep != undefined) {
+      sleeptime = spec.sleep;
+    }
     setTimeout(
 	function(){ setInterval(function() {
 	    //to be on the save side re-register. Agent will realize if already existing
@@ -125,5 +135,5 @@ sensorSpecs.forEach(function(spec){
 		    process.exit(0);
 		}
 	    })
-	}, 5 * 1000)}, 10000)
+	}, sleeptime)}, 10000)
 });

--- a/lib/cloud.proxy.js
+++ b/lib/cloud.proxy.js
@@ -245,7 +245,7 @@ IoTKitCloud.prototype.dataSubmit = function (metric, callback) {
         }
         data.convertToMQTTPayload = function() {
             delete this.convertToMQTTPayload;
-            return this;
+            return this.body;
         }
         data.did = metric.did;
         data.accountId = metric.accountId;
@@ -374,6 +374,9 @@ IoTKitCloud.prototype.getActualTime = function (callback) {
  */
 IoTKitCloud.prototype.updateComponents = function (data) {
     var me = this;
+    if (data == undefined) {
+        return;
+    }
     data.forEach(function(cloudSensor) {
         var sen = {}
         sen.cid = cloudSensor.cid;


### PR DESCRIPTION
* Moved Containers to node v10.19.0
* Made sleep-time configurable in testsensor script (to allow loadtests with less clients)
* Reduce size of mqtt message on the wire by only sending body (which is now supported by OISP).
* Catch case when components are not defined but agents tries to fetch from upstream