### PR TITLE
Updates to work with changes in OISP MQTT service:

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
       TZ: "Europe/Berlin"
   docker-executor:
     docker:
-      - image: circleci/node:8.0
+      - image: circleci/node:10.19.0
     working_directory: ~/repo
     environment:
       shell: /bin/bash
@@ -27,8 +27,12 @@ commands:
       - run:
           name: Setup build environment
           command: |
-            cd platform-launcher/platform-setup
-            sudo ./setup-ubuntu16.04.sh
+            cd platform-launcher/util && \
+            bash setup-ubuntu18.04.sh
+            # create 8GB swap
+            sudo dd if=/dev/zero of=/swapfile bs=1M count=8000
+            sudo mkswap /swapfile
+            sudo swapon /swapfile
   checkout-e2e:
     description: "Checkout E2E test"
     parameters:
@@ -57,7 +61,8 @@ commands:
             cd platform-launcher
             docker login  -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
             export DOCKER_TAG="<< parameters.oisp-tag >>"
-            yes | make pull
+            docker-compose pull
+            docker pull oisp/debugger:${DOCKER_TAG}
   e2e-test:
     description: "Wait for platform to become ready"
     parameters:
@@ -69,12 +74,17 @@ commands:
           shell: /bin/bash
           command: |
             export NVM_DIR="/opt/circleci/.nvm"
+            export PATH=/snap/bin:$PATH
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm install v8.16.0
             nvm alias default v8.16.0
             cd platform-launcher
             export DOCKER_TAG=<< parameters.oisp-docker-tag >>
+            make import-images DEBUG=true
+            export NODOCKERLOGIN=true
+            make deploy-oisp-test
             make test-prep-only
+
   checkout-testbranch:
     description: "Checks out branch of repository which is to be tested"
     parameters:
@@ -108,13 +118,18 @@ commands:
           name: Test admin tool
           shell: /bin/bash
           command: |
+            wget https://github.com/txn2/kubefwd/releases/download/1.13.0/kubefwd_amd64.deb
+            sudo dpkg -i kubefwd_amd64.deb
+            sudo -E KUBECONFIG=/home/circleci/k3s/kubeconfig.yaml kubefwd svc -n oisp -l "app in (frontend, websocket-server, mqtt-server)"&
+            sleep 10
             export NVM_DIR="/opt/circleci/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm install v8.16.0
             nvm alias default v8.16.0
             cd platform-launcher/oisp-iot-agent
+            sudo rm -rf /home/circleci/.npm
             npm install
-            cp config/config.json.template config/config.json
+            cp config/config.json.circleci config/config.json
             ./oisp-admin.js test
   test-agent:
     description: "Test agent"
@@ -123,27 +138,31 @@ commands:
           name: Test agent
           shell: /bin/bash
           command: |
+            wget https://github.com/txn2/kubefwd/releases/download/1.13.0/kubefwd_amd64.deb
+            sudo dpkg -i kubefwd_amd64.deb
+            sudo -E KUBECONFIG=/home/circleci/k3s/kubeconfig.yaml kubefwd svc -n oisp -l "app in (frontend, websocket-server, mqtt-server)"&
+            sleep 10
             export NVM_DIR="/opt/circleci/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
             nvm install v8.16.0
             nvm alias default v8.16.0
             cd platform-launcher/oisp-iot-agent
             npm install
-            cp config/config.json.template config/config.json
+            cp config/config.json.circleci config/config.json
             make test
 jobs:
   e2e-test:
     executor: vm-executor
     steps:
       - checkout-e2e:
-          oisp-git-hash: "v1.1.1-beta.1"
+          oisp-git-hash: "e022b7f0c2f21acdda40f34c2d8ee3bab76ca667"
       - checkout-testbranch:
           repo: "oisp-iot-agent"
       - setup-build-environment
       - pull-images:
-          oisp-tag: "v1.1.1-beta.1"
+          oisp-tag: "nightly-2020-03-27"
       - e2e-test:
-          oisp-docker-tag: "v1.1.1-beta.1"
+          oisp-docker-tag: "nightly-2020-03-27"
       - test-admin
       - test-agent
   build-check:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.16.0-alpine
+FROM node:10.19.0-alpine
 
 ADD . /app
 

--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,12 @@ clean: stop
 	@docker rm -f ${CONTAINER_NAME} || echo "${CONTAINER_NAME} cannot be deleted"
 	@/bin/bash -c "docker rmi -f ${IMAGE_NAME}" || echo "${IMAGE_NAME} cannot be deleted"
 	@rm -f .prepare-testconfig
+	@make -C container clean
+	@./oisp-admin.js  reset-data-directory
+	@rm -f config/config.json
 
 .prepare-testconfig:
-		@cp config/config.json.template config/config.json
+		@cp config/config.json.circleci config/config.json
 		cd ${GETAGENTENVDIR} && make build && source ./getActivationCode.sh ${USERNAME} ${PASSWORD} ${DEVICENAME}
 		@touch $@
 

--- a/config/config.json.circleci
+++ b/config/config.json.circleci
@@ -1,0 +1,54 @@
+{
+	"data_directory": "./data",
+	"listeners": {
+		"rest_port": 8000,
+		"udp_port": 41234,
+		"tcp_port": 7070
+	},
+	"receivers": {
+		"udp_port": 41235,
+		"udp_address": "0.0.0.0"
+	},
+	"logger": {
+		"level": "info",
+		"path": "/tmp/",
+		"max_size": 134217728
+	},
+	"default_connector": "rest+ws",
+	"connector": {
+		"rest": {
+			"host": "frontend",
+			"port": 4001,
+			"protocol": "http",
+			"strictSSL": false,
+			"timeout": 30000,
+			"proxy": {
+				"host": false,
+				"port": false
+			}
+		},
+		"ws": {
+			"host": "websocket-server",
+			"port": 5000,
+			"minRetryTime": 2500,
+			"maxRetryTime": 600000,
+			"testTimeout": 40000,
+			"pingPongIntervalMs": 30000,
+			"enablePingPong": true,
+			"secure": false,
+			"proxy": {
+				"host": false,
+				"port": false
+			}
+		},
+		"mqtt": {
+			"host": "mqtt-server",
+			"port": 8883,
+			"qos": 1,
+			"retain": false,
+			"secure": true,
+			"strictSSL": true,
+			"retries": 5
+		}
+	}
+}

--- a/container/Dockerfile.testsensor
+++ b/container/Dockerfile.testsensor
@@ -1,4 +1,4 @@
-FROM node:8.16.0-alpine
+FROM node:10.19.0-alpine
 
 ADD ./scripts/testsensor /app
 

--- a/container/Makefile
+++ b/container/Makefile
@@ -27,7 +27,7 @@ stop:
 clean: stop
 	@$(call msg,"Cleaning ...");
 	@/bin/bash -c "docker rmi ${IMAGE_NAME}" || echo "${IMAGE_NAME} cannot be deleted"
-	make -C scripts/getagentenv clean
+	@make -C test clean
 
 test: build start
 	@make -C test test

--- a/container/scripts/agent/onboard.sh
+++ b/container/scripts/agent/onboard.sh
@@ -24,7 +24,7 @@ ADMIN=../../../oisp-admin.js
 echo onboarding with OISP_DEVICE_ACTIVATION_CODE=${OISP_DEVICE_ACTIVATION_CODE} OISP_DEVICE_ID=${OISP_DEVICE_ID} OISP_FORCE_REACTIVATION=${OISP_FORCE_REACTIVATION} OISP_DEVICE_NAME=${OISP_DEVICE_NAME}
 TOKEN=$(cat ${DATADIR}/device.json | jq ".device_token")
 echo Token found: $TOKEN
-if [ "$TOKEN" = "\"\"" ] || [ "$TOKEN" = "false" ] || [ ! -z "$OISP_FORCE_REACTIVATION" ]; then
+if [ -z "$TOKEN" ] || [ "$TOKEN" = "\"\"" ] || [ "$TOKEN" = "false" ] || [ ! -z "$OISP_FORCE_REACTIVATION" ]; then
     if [ -z "$OISP_DEVICE_ACTIVATION_CODE" ]; then
         fail "No Device Activation Code given but no token found or reactivation is forced"
     fi

--- a/container/scripts/testsensor/testsensor.js
+++ b/container/scripts/testsensor/testsensor.js
@@ -37,6 +37,7 @@ var default_sensorSpecs = [
 	componentName: "temp",
 	componentType: "temperature.v1.0",
 	type: "number",
+  sleep: 5000,
 	sigma: 0.3,
 	startValue: 20
     }
@@ -63,6 +64,10 @@ if (process.env.TEST_SAMPLES) {
 }
 
 var registerComponent = function(spec) {
+    spec.compRegistering++;
+    if (spec.compRegistering > 5) {
+      return;
+    }
     var component = { "t": spec.componentType, "n": spec.componentName }
     var comp_message = new Buffer(JSON.stringify(component));
     spec.agents.forEach(function(agent){
@@ -93,6 +98,7 @@ var getRandomInteger = function(min, max) {
 //initialize all values
 sensorSpecs.forEach(function(spec) {
     values[spec.name] = spec.startValue;
+    spec.compRegistering = 0;
 });
 
 //first register the temp component
@@ -102,6 +108,10 @@ sensorSpecs.forEach(function(spec) {
 });
 
 sensorSpecs.forEach(function(spec){
+    var sleeptime = 5000;
+    if (spec.sleep != undefined) {
+      sleeptime = spec.sleep;
+    }
     setTimeout(
 	function(){ setInterval(function() {
 	    //to be on the save side re-register. Agent will realize if already existing
@@ -125,5 +135,5 @@ sensorSpecs.forEach(function(spec){
 		    process.exit(0);
 		}
 	    })
-	}, 5 * 1000)}, 10000)
+	}, sleeptime)}, 10000)
 });

--- a/container/test/Makefile
+++ b/container/test/Makefile
@@ -19,6 +19,7 @@ build:
 clean:
 	@$(call msg,"Cleaning environent for oisp-cli ...")
 	rm -f testconfig.sh
+	rm -rf node_modules
 
 test:
 	@./agent-test.sh CLIBIN=${CLIBIN} CLIDIR=${CLIDIR}

--- a/container/test/getSamples.sh
+++ b/container/test/getSamples.sh
@@ -22,4 +22,4 @@ COMPONENTNAME=$3
 echo Executing with ACCOUNT_NAME=${ACCOUNTID} DEVICEID=${DEVICEID} COMPONENTNAME=${COMPONENTNAME} 1>&2
 # get token
 ${CLIBIN} devices.get ${ACCOUNTID}
-${CLIBIN} data.post.search ${ACCOUNTID} ${DEVICEID} ${COMPONENTNAME} 0 $(date +%s) | grep series |  sed 's/.*Info.*retrieved:  \({.*}\)/\1/' | jq '.series[0].points | length'
+${CLIBIN} data.post.search ${ACCOUNTID} ${DEVICEID} ${COMPONENTNAME} 0 $(( $(date +%s) * 1000 )) | grep series |  sed 's/.*Info.*retrieved:  \({.*}\)/\1/' | jq '.series[0].points | length'

--- a/lib/cloud.proxy.js
+++ b/lib/cloud.proxy.js
@@ -245,7 +245,7 @@ IoTKitCloud.prototype.dataSubmit = function (metric, callback) {
         }
         data.convertToMQTTPayload = function() {
             delete this.convertToMQTTPayload;
-            return this;
+            return this.body;
         }
         data.did = metric.did;
         data.accountId = metric.accountId;
@@ -374,6 +374,9 @@ IoTKitCloud.prototype.getActualTime = function (callback) {
  */
 IoTKitCloud.prototype.updateComponents = function (data) {
     var me = this;
+    if (data == undefined) {
+        return;
+    }
     data.forEach(function(cloudSensor) {
         var sen = {}
         sen.cid = cloudSensor.cid;


### PR DESCRIPTION
* Moved Containers to node v10.19.0
* Made sleep-time configurable in testsensor script (to allow loadtests with less clients)
* Reduce size of mqtt message on the wire by only sending body (which is now supported by OISP).
* Catch case when components are not defined but agents tries to fetch from upstream
* Update circleci config

Signed-off-by: Marcel Wagner <wagmarcel@web.de>